### PR TITLE
Introducing Bean Control via RL + Differential Model Predictive Control (MPC)

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -6,6 +6,7 @@ import torch.nn as nn
 from rl_zoo3 import linear_schedule
 from stable_baselines3 import PPO
 from stable_baselines3.common.callbacks import EvalCallback
+#from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.env_checker import check_env
 
 from wandb.integration.sb3 import WandbCallback
@@ -89,8 +90,8 @@ def main():
     env = make_env(config)
 
     # Check the environment
-    check_env(env, warn=True, skip_render_check=True)
-    
+    #check_env(env, warn=True, skip_render_check=True)
+
     # Setup evaluation environment
     eval_env = make_env(config, plot_episode=True, log_task_statistics=True)
 

--- a/runner.py
+++ b/runner.py
@@ -100,8 +100,8 @@ def main():
 
     # Setup RL training algorithm
     model = PPO(
-        "MlpPolicy",
-        #MPCPolicy,  # Use the custom policy
+        #"MlpPolicy",
+        MPCPolicy,  # Use the custom policy
         env,
         learning_rate=config["learning_rate"],
         n_steps=config["n_steps"],
@@ -125,7 +125,7 @@ def main():
             }[config["net_arch"]],
             "ortho_init": config["ortho_init"],
             "log_std_init": config["log_std_init"],
-            #"env": env,
+            "env": env,
         },
         device=config["sb3_device"],
         tensorboard_log=f"log/{config['run_name']}",

--- a/runner.py
+++ b/runner.py
@@ -56,7 +56,7 @@ def main():
     "ent_coef": 0.0,
     "n_epochs": 10,
     "gae_lambda": 0.95,
-    "clip_range": 0.2,
+    "clip_range": 0.2, # Try: 0.1 to make updates more conservative.
     "clip_range_vf": None,
     "vf_coef": 0.5,
     "max_grad_norm": 0.5,

--- a/runner.py
+++ b/runner.py
@@ -127,6 +127,8 @@ def main():
             "ortho_init": config["ortho_init"],
             "log_std_init": config["log_std_init"],
             "env": env,
+            "state_dim": 4, # Pass in the value 4, not the length of the observation space, 13, from self._get_obs()!
+            "action_dim": 5,
         },
         device=config["sb3_device"],
         tensorboard_log=f"log/{config['run_name']}",

--- a/runner.py
+++ b/runner.py
@@ -73,6 +73,11 @@ def main():
     
     # ===== SB3 configuration =====
     "sb3_device": "auto",
+
+    # ===== MPC parameters =====
+    "horizon": 5,
+    "lqr_iter": 5,
+    "R_scale": 0.01,
     }
 
     # Setup wandb
@@ -127,6 +132,9 @@ def main():
             "ortho_init": config["ortho_init"],
             "log_std_init": config["log_std_init"],
             "env": env,
+            "horizon": config["horizon"],
+            "lqr_iter": config["lqr_iter"],
+            "R_scale": config["R_scale"],
         },
         device=config["sb3_device"],
         tensorboard_log=f"log/{config['run_name']}",

--- a/runner.py
+++ b/runner.py
@@ -127,8 +127,6 @@ def main():
             "ortho_init": config["ortho_init"],
             "log_std_init": config["log_std_init"],
             "env": env,
-            "state_dim": 4, # Pass in the value 4, not the length of the observation space, 13, from self._get_obs()!
-            "action_dim": 5,
         },
         device=config["sb3_device"],
         tensorboard_log=f"log/{config['run_name']}",

--- a/runner.py
+++ b/runner.py
@@ -51,7 +51,7 @@ def main():
     "learning_rate": 0.0003,
     "lr_schedule": "constant",
     "gamma": 0.75,
-    "n_envs": 1,  # Using a single environment
+    "n_envs": 40,  # Using a single environment
     "n_steps": 256,
     "ent_coef": 0.0,
     "n_epochs": 10,

--- a/src/environments/beam_dynamics.py
+++ b/src/environments/beam_dynamics.py
@@ -47,22 +47,13 @@ class BeamDynamics(nn.Module):
         x = x.clone().requires_grad_(True).to(self.device)
         u = u.clone().requires_grad_(True).to(self.device)
 
-        #mu_x = torch.as_tensor(x[0, 0], dtype=x.dtype, device=x.device)
-        #mu_x.requires_grad_(True)
-        #mu_y = torch.as_tensor(x[0, 1], dtype=x.dtype, device=x.device)
-        #mu_y.requires_grad_(True)
-        #sigma_x = torch.as_tensor(x[0, 2], dtype=x.dtype, device=x.device)
-        #sigma_x.requires_grad_(True)
-        #sigma_y = torch.as_tensor(x[0, 3], dtype=x.dtype, device=x.device)
-        #sigma_y.requires_grad_(True)
-
-        # Extract parameters with batch dimension
-        mu_x = x[:, 0].clone().requires_grad_(True)  # Shape: [batch_size]
-        mu_y = x[:, 1].clone().requires_grad_(True)
-        sigma_x = x[:, 2].clone().requires_grad_(True)
-        sigma_y = x[:, 3].clone().requires_grad_(True)
-
         # Create beam with batched parameters
+        mu_x = x[:, 0]  # Shape: [batch_size]
+        mu_y = x[:, 1]
+        sigma_x = x[:, 2]
+        sigma_y = x[:, 3]
+
+        # Create beam
         beam = self.incoming.transformed_to(
             energy=self.incoming_params[0],  # Fixed, no gradients needed
             mu_x=mu_x,  # Dynamic, batched
@@ -77,19 +68,24 @@ class BeamDynamics(nn.Module):
             sigma_p=self.incoming_params[10],  # Fixed, no gradients needed
         )
 
+        # Set magnets
+        self._set_magnets(u)
+
         # Track beam
         next_beam = self.segment.track(beam)
 
         # Extract next state, preserving batch dimension
         x_next = torch.stack(
             [
-                next_beam.mu_x, #.clone().requires_grad_(True),
-                next_beam.mu_y, #.clone().requires_grad_(True),
-                next_beam.sigma_x, #.clone().requires_grad_(True),
-                next_beam.sigma_y, #.clone().requires_grad_(True),
+                next_beam.mu_x.clone().requires_grad_(True),
+                next_beam.mu_y.clone().requires_grad_(True),
+                next_beam.sigma_x.clone().requires_grad_(True),
+                next_beam.sigma_y.clone().requires_grad_(True),
             ],
             dim=-1,
-        ).to(dtype=torch.float32)  # Shape: [batch_size, 4]
+        ).to(
+            dtype=torch.float32
+        )  # Shape: [batch_size, 4]
 
         return x_next
 
@@ -97,7 +93,7 @@ class BeamDynamics(nn.Module):
         """
         Set magnet parameters based on control input u.
         """
-        # Direct assignment to preserve u's graph and  gradients
+        # Direct assignment to preserve u's graph and gradients
         self.segment.AREAMQZM1.k1 = u[:, 0].clone().requires_grad_(True)
         self.segment.AREAMQZM2.k1 = u[:, 1].clone().requires_grad_(True)
         self.segment.AREAMCVM1.angle = u[:, 2].clone().requires_grad_(True)

--- a/src/environments/beam_dynamics.py
+++ b/src/environments/beam_dynamics.py
@@ -12,7 +12,11 @@ class BeamDynamics(nn.Module):
         incoming_parameters,
     ):
         super().__init__()
-        self.segment = copy.deepcopy(segment)
+
+        #self.segment = copy.deepcopy(segment)
+        # Assuming `segment` is of type nn.Module
+        self.segment = type(segment)()  # Creates a blank model of the same class
+        self.segment.load_state_dict(segment.state_dict(), strict=False) # Injects those values into the new model
 
         # Store incoming_parameters as a Parameter to ensure it stays in the graph
         self.incoming_params = copy.deepcopy(incoming_parameters)

--- a/src/environments/cheetah_env.py
+++ b/src/environments/cheetah_env.py
@@ -275,10 +275,10 @@ class CheetahEnv(gym.Env, TransverseTuningBaseBackend):
         )
 
         # Create a beam dynamics model
-        #self.dynamics = BeamDynamics(
-        #    segment=self.segment,
-        #    incoming_parameters=self.incoming_params,
-        #)
+        self.dynamics = BeamDynamics(
+            segment=self.segment,
+            incoming_parameters=self.incoming_params,
+        )
 
         # Set up misalignments
         if "misalignments" in preprocessed_options:

--- a/src/environments/cheetah_env.py
+++ b/src/environments/cheetah_env.py
@@ -6,6 +6,7 @@ import gymnasium as gym
 import numpy as np
 import torch
 from gymnasium import spaces
+
 from src.environments.base_backend import TransverseTuningBaseBackend
 from src.environments.beam_dynamics import BeamDynamics
 from src.environments.differential_area_segment import DifferentialAREASegment
@@ -190,7 +191,7 @@ class CheetahEnv(gym.Env, TransverseTuningBaseBackend):
         self.generate_screen_images = generate_screen_images
         self.simulate_finite_screen = simulate_finite_screen
 
-        # Initialize differentiable segment to setup simulation
+        # Initialize differentiable segment setup simulation
         self.segment = DifferentialAREASegment()
 
         # Spaces for domain randomisation
@@ -259,6 +260,7 @@ class CheetahEnv(gym.Env, TransverseTuningBaseBackend):
             incoming_parameters, dtype=torch.float32, requires_grad=True
         )
 
+        # Create beam
         self.incoming = cheetah.ParameterBeam.from_parameters(
             energy=self.incoming_params[0],
             mu_x=self.incoming_params[1],

--- a/src/environments/cheetah_env.py
+++ b/src/environments/cheetah_env.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Literal, Optional, Tuple, Union
+from collections import OrderedDict
 
 import cheetah
 import cv2
@@ -134,7 +135,7 @@ class CheetahEnv(gym.Env, TransverseTuningBaseBackend):
             )
 
         # Create observation space
-        self.observation_space = spaces.Dict(
+        self.observation_space = spaces.Dict(OrderedDict(
             {
                 "beam": spaces.Box(
                     low=np.array([-np.inf, 0, -np.inf, 0], dtype=np.float32),
@@ -146,7 +147,7 @@ class CheetahEnv(gym.Env, TransverseTuningBaseBackend):
                     high=np.array([2e-3, 2e-3, 2e-3, 2e-3], dtype=np.float32),
                 ),
             }
-        )
+        ))
 
         # Create action space
         if self.action_mode == "direct":

--- a/src/environments/cheetah_env.py
+++ b/src/environments/cheetah_env.py
@@ -395,17 +395,6 @@ class CheetahEnv(gym.Env, TransverseTuningBaseBackend):
 
     def get_magnets(self) -> np.ndarray:
         """Get current magnet settings."""
-        # return np.array(
-        #    [
-        #        self.segment.AREAMQZM1.k1.detach().cpu().numpy(),
-        #        self.segment.AREAMQZM2.k1.detach().cpu().numpy(),
-        #        self.segment.AREAMCVM1.angle.detach().cpu().numpy(),
-        #        self.segment.AREAMQZM3.k1.detach().cpu().numpy(),
-        #        self.segment.AREAMCHM1.angle.detach().cpu().numpy(),
-        #    ],
-        #    dtype=np.float32
-        # )
-        # torch.tensor([])
         torch_tensor = torch.stack(
             [
                 self.segment.AREAMQZM1.k1,

--- a/src/environments/mpc_controller.py
+++ b/src/environments/mpc_controller.py
@@ -4,7 +4,7 @@ from gymnasium.spaces import Dict
 from mpc.mpc import MPC, GradMethods, QuadCost
 
 
-class MPCController(gym.Wrapper):
+class MPCController:
     """
     Model Predictive Control (MPC) based controller for beam control.
     This class encapsulates the MPC algorithm logic, separating it from the environment.
@@ -54,39 +54,47 @@ class MPCController(gym.Wrapper):
             self.action_dim, dtype=torch.float32
         )  # Control cost (n_ctrl)
 
-    def reset(self, **kwargs):
-        """
-        Explicitly initialize the internal BeamDynamics object and segment parameters.
-        Should be called after env.reset() from an external handler.
-        """
-        obs, info = self.env.unwrapped.reset(**kwargs)
-
-        return obs, info
-
     def get_action_from_cost_params(self, state, q_diag, p):
-        batch_size = state.shape[0]
+        # Add batch dimension if missing
+        if state.dim() == 1:
+            state = state.unsqueeze(0)  # [1, state_dim], e.g., [1, 4]
+        if q_diag.dim() == 1:
+            q_diag = q_diag.unsqueeze(0)  # [1, 9]
+        if p.dim() == 1:
+            p = p.unsqueeze(0)  # [1, 9]
 
+        batch_size = state.shape[0]  # Should be 1 for single environment
+
+        # Quadratic terms
         # Q is a diagonal matrix penalizing the combined state and control vector [x; u],
         # where x is the state (4D) and u is the control (5D).
-        Q = torch.diag_embed(q_diag)  # [batch_size, 9, 9], diagonal matrix
+        # Q as a diagonal matrix: [batch_size, 9, 9]
+        Q = torch.diag_embed(q_diag)  # [1, 9, 9] for batch_size=1
 
         # Repeat for horizon (assuming same cost per step)
-        Q_running = Q.unsqueeze(0).repeat(self.horizon, 1, 1, 1)
-        p_running = p.unsqueeze(0).repeat(self.horizon, 1, 1)
+        # Running cost: [horizon, batch_size, 9, 9]
+        Q_running = Q.unsqueeze(0).repeat(self.horizon, 1, 1, 1)  # [horizon, 1, 9, 9]
 
         # Terminal cost (using same as running cost for simplicity)
-        Q_terminal = Q.unsqueeze(0)
-        p_terminal = p.unsqueeze(0)
+        # Terminal cost: [1, batch_size, 9, 9]
+        Q_terminal = Q.unsqueeze(0)  # [1, 1, 9, 9]
 
         # Combine into cost tensors for QuadCost - stack them properly
-        C = torch.cat([Q_running, Q_terminal], dim=0)
-        c = torch.cat([p_running, p_terminal], dim=0)
+        # Combine: [horizon + 1, batch_size, 9, 9]
+        C = torch.cat([Q_running, Q_terminal], dim=0)  # [horizon + 1, 1, 9, 9]
+
+        # Linear terms
+        p_running = p.unsqueeze(0).repeat(self.horizon, 1, 1)  # [horizon, 1, 9]
+        # Terminal cost (using same as running cost for simplicity)
+        p_terminal = p.unsqueeze(0)  # [1, 1, 9]
+        # Combine into cost tensors for QuadCost - stack them properly
+        c = torch.cat([p_running, p_terminal], dim=0)  # [horizon + 1, 1, 9]
 
         # Construct cost for QuadCost, running cost for [s; u]
         # The cost is repeated over the horizon and includes a terminal cost
         cost = QuadCost(C, c)
 
-        # Control bounds
+        # Control bounds: [horizon, batch_size, action_dim]
         u_lower = (
             self.u_lower.unsqueeze(0)
             .unsqueeze(0)
@@ -117,12 +125,14 @@ class MPCController(gym.Wrapper):
 
         # Create dynamics here instead of fetching it
         dynamics = self.env.unwrapped.dynamics
+        #dynamics = self.env.dynamics
 
-        with torch.enable_grad():  # Force gradient tracking
-            x_lqr, u_lqr, _ = mpc(state, cost, dynamics)
+        #with torch.enable_grad():  # Force gradient tracking
+        #    x_lqr, u_lqr, _ = mpc(state, cost, dynamics)
 
         # Detach first action for environment stepping
-        action = u_lqr[0, 0].detach()
-        print("Action:", action, "u_lqr:", u_lqr)
+        #action = u_lqr[0, 0].detach()
+        #print("Action:", action, "u_lqr:", u_lqr)
+        action = torch.tensor([72.0/2, 72.0/2, 6.1782e-3/2, 72.0/2, 6.1782e-3/2], dtype=torch.float32, requires_grad=True).detach()
 
         return action

--- a/src/environments/mpc_controller.py
+++ b/src/environments/mpc_controller.py
@@ -44,9 +44,13 @@ class MPCController:
         self.R_scale = R_scale
 
         # Action bounds as tensors
-        self.u_lower = torch.tensor(env.unwrapped.action_space.low, dtype=torch.float32)
+        self.u_lower = torch.tensor(
+            env.unwrapped.action_space.low,
+            dtype=torch.float32
+        )
         self.u_upper = torch.tensor(
-            env.unwrapped.action_space.high, dtype=torch.float32
+            env.unwrapped.action_space.high,
+            dtype=torch.float32
         )
 
         # Control cost matrix R (assuming diagonal as in the proposed version)
@@ -85,8 +89,10 @@ class MPCController:
 
         # Linear terms
         p_running = p.unsqueeze(0).repeat(self.horizon, 1, 1)  # [horizon, 1, 9]
+
         # Terminal cost (using same as running cost for simplicity)
         p_terminal = p.unsqueeze(0)  # [1, 1, 9]
+
         # Combine into cost tensors for QuadCost - stack them properly
         c = torch.cat([p_running, p_terminal], dim=0)  # [horizon + 1, 1, 9]
 
@@ -120,7 +126,6 @@ class MPCController:
             verbose=1,  # Debug MPC internals
             backprop=True,
             delta_u=0.1,
-            # u_init: The initial control sequence, useful for warm-starting: [T, n_batch, n_ctrl]
         )
 
         # Create dynamics here instead of fetching it
@@ -131,6 +136,5 @@ class MPCController:
 
         # Detach first action for environment stepping
         action = u_lqr[0, 0].detach()
-        print("Action:", action, "u_lqr:", u_lqr)
 
         return action

--- a/src/environments/mpc_controller.py
+++ b/src/environments/mpc_controller.py
@@ -125,14 +125,12 @@ class MPCController:
 
         # Create dynamics here instead of fetching it
         dynamics = self.env.unwrapped.dynamics
-        #dynamics = self.env.dynamics
 
-        #with torch.enable_grad():  # Force gradient tracking
-        #    x_lqr, u_lqr, _ = mpc(state, cost, dynamics)
+        with torch.enable_grad():  # Force gradient tracking
+            x_lqr, u_lqr, _ = mpc(state, cost, dynamics)
 
         # Detach first action for environment stepping
-        #action = u_lqr[0, 0].detach()
-        #print("Action:", action, "u_lqr:", u_lqr)
-        action = torch.tensor([72.0/2, 72.0/2, 6.1782e-3/2, 72.0/2, 6.1782e-3/2], dtype=torch.float32, requires_grad=True).detach()
+        action = u_lqr[0, 0].detach()
+        print("Action:", action, "u_lqr:", u_lqr)
 
         return action

--- a/src/environments/mpc_policy.py
+++ b/src/environments/mpc_policy.py
@@ -24,8 +24,6 @@ class MPCPolicy(ActorCriticPolicy):
         action_space: spaces.Box,  # 18D
         lr_schedule: Callable[[float], float],
         env=None,
-        state_dim=4,  # TODO: IS IT NEEDED HERE??
-        action_dim=5, # TODO: IS IT NEEDED HERE??
         horizon=15,  # typical range: 10–20 to consider longer-term effects
         lqr_iter=25, # typical range: 5–50 iterations
         R_scale=0.5, # 0.1–1.0 to penalize control effort more, encouraging smoother actions
@@ -45,8 +43,8 @@ class MPCPolicy(ActorCriticPolicy):
         self.env = env
 
         # Redefine action_space as cost parameters (18D for Q diagonal + p)
-        self.state_dim = state_dim  # Use passed state_dim
-        self.action_dim = action_dim  # Use passed action_dim
+        self.state_dim = self.env.unwrapped.observation_space["beam"].shape[0]
+        self.action_dim = self.env.unwrapped.action_space.shape[0]
         self.combined_dim = self.state_dim + self.action_dim
 
         # MPC setup

--- a/src/environments/mpc_policy.py
+++ b/src/environments/mpc_policy.py
@@ -20,44 +20,39 @@ class MPCPolicy(ActorCriticPolicy):
 
     def __init__(
         self,
-        observation_space: spaces.Space,
-        action_space: spaces.Box,
+        observation_space: spaces.Space,  # 13D
+        action_space: spaces.Box,  # 18D
         lr_schedule: Callable[[float], float],
         env=None,
-        state_dim=4,
-        action_dim=5,
-        horizon=15,  # typical range: 10–20 to consider longer-term effects.
+        state_dim=4,  # TODO: IS IT NEEDED HERE??
+        action_dim=5, # TODO: IS IT NEEDED HERE??
+        horizon=15,  # typical range: 10–20 to consider longer-term effects
         lqr_iter=25, # typical range: 5–50 iterations
-        R_scale=0.5, # 0.1–1.0 to penalize control effort more, encouraging smoother actions. Start with 0.1 and observe if the cost varies across iterations.
+        R_scale=0.5, # 0.1–1.0 to penalize control effort more, encouraging smoother actions
         target_state_fn: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
         net_arch: Optional[List[Union[int, Dict[str, List[int]]]]] = None,
         activation_fn: Type[nn.Module] = nn.Tanh,
         *args,
         **kwargs
     ):
+        super().__init__(observation_space, action_space, lr_schedule, *args, **kwargs)
+
         # Define defaults
         if net_arch is None:
             net_arch = [dict(pi=[64, 64], vf=[64, 64])]
 
-        # Redefine action_space as cost parameters (18D for Q diagonal + p)
-        self.state_dim = state_dim
-        self.action_dim = action_dim
-        self.combined_dim = state_dim + action_dim
-        action_space = spaces.Box(
-            low=-10, high=10, shape=(self.combined_dim * 2,), dtype=np.float32
-        )  # 18D
-
-        super().__init__(observation_space, action_space, lr_schedule, *args, **kwargs)
-
-        # Environment and MPC setup
+        # Environment
         self.env = env
+
+        # Redefine action_space as cost parameters (18D for Q diagonal + p)
+        self.state_dim = state_dim  # Use passed state_dim
+        self.action_dim = action_dim  # Use passed action_dim
+        self.combined_dim = self.state_dim + self.action_dim
+
+        # MPC setup
         self.horizon = horizon
         self.lqr_iter = lqr_iter
         self.R_scale = R_scale
-
-        self.mpc_controller = MPCController(
-            self.env, self.horizon, self.lqr_iter, self.R_scale
-        )
 
         # Function to extract target state from observation
         self.target_state_fn = (
@@ -88,76 +83,40 @@ class MPCPolicy(ActorCriticPolicy):
     def forward(self, obs: torch.Tensor, deterministic=False):
         """
         Forward pass: Predict cost parameters and map to control actions via MPC.
+
+        Sample and return 18D cost parameters.
+        The wrapper will convert these to 5D control actions.
         """
         # Extract features
         latent_pi, latent_vf = self.mlp_extractor(obs)  # Use mlp_extractor directly
 
-        # Extract current and target states
-        current_state = obs[:, : self.state_dim].to(torch.float32)
-        target_state = self.target_state_fn(obs).to(torch.float32) # TODO: NOT USED!
-        current_state.requires_grad_(True)
-        target_state.requires_grad_(True) # TODO: NOT USED!
-
         # Get cost parameters distribution from actor
         dist = self._get_action_dist_from_latent(latent_pi)
+
+        # The differential-MPC cost parameters
         cost_params = dist.get_actions(deterministic=deterministic)  # [batch_size, 18]
-        q_diag = torch.exp(
-            cost_params[:, : self.combined_dim]
-        )  # Ensure positive diagonal
-        p = cost_params[:, self.combined_dim:]
-
-        # Map cost parameters to control actions via MPC
-        #action = self.mpc_controller.get_action_from_cost_params(
-        #    current_state, q_diag, p
-        #)
-        action = torch.tensor([72.0/2, 72.0/2, 6.1782e-3/2, 72.0/2, 6.1782e-3/2], dtype=torch.float32, requires_grad=True).detach()
-
-
-        #print("q_diag grad norm:", q_diag.grad.norm() if q_diag.grad is not None else 0)
-        #print("p grad norm:", p.grad.norm() if p.grad is not None else 0)
-
-        # Get value estimate from critic
-        values = self.value_net(latent_vf)
 
         # Log probability of the cost parameters (not actions)
         log_prob = dist.log_prob(cost_params) if not deterministic else None
 
-        return action, values, log_prob
+        # Get value estimate from critic
+        values = self.value_net(latent_vf)
+
+        # The cost_params represent the non-control actions
+        return cost_params, values, log_prob # output the cost_params
 
     def evaluate_actions(
         self, obs: torch.Tensor, actions: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor]]:
         """
         Evaluate the log probability of actions (cost parameters) and compute values.
+        Evaluate log probabilities of the 18D cost parameters.
         """
         latent_pi, latent_vf = self.mlp_extractor(obs)
 
-        # Extract current and target states
-        current_state = obs[:, : self.state_dim].to(torch.float32)
-        target_state = self.target_state_fn(obs).to(torch.float32)  # TODO: NOT USED!
-
         # Get predicted cost parameters from actor
         dist = self._get_action_dist_from_latent(latent_pi)
-        predicted_cost_params = dist.get_actions(deterministic=True)  # [batch_size, 18]
-
-        # Since `actions` from the rollout buffer are control actions (5D), we need to compare
-        # them with the MPC output, not the cost parameters directly
-        q_diag = torch.exp(predicted_cost_params[:, : self.combined_dim])
-        p = predicted_cost_params[:, self.combined_dim:]
-
-        #predicted_actions = self.mpc_controller.get_action_from_cost_params(
-        #    current_state, q_diag, p
-        #)
-        predicted_actions = torch.tensor([72.0/2, 72.0/2, 6.1782e-3/2, 72.0/2, 6.1782e-3/2], dtype=torch.float32, device=actions.device)
-        #predicted_actions = torch.tensor(
-        #    predicted_actions, dtype=torch.float32, device=actions.device
-        #)
-
-        # Simplified log probability: Gaussian approximation around predicted control actions
-        action_var = torch.ones_like(actions) * 0.1  # Fixed variance
-        log_prob = -0.5 * torch.sum(
-            ((actions - predicted_actions) ** 2) / action_var, dim=-1
-        )
+        log_prob = dist.log_prob(actions)  # actions are 18D cost parameters
 
         # Value estimate
         values = self.value_net(latent_vf)
@@ -165,5 +124,5 @@ class MPCPolicy(ActorCriticPolicy):
         return (
             values,
             log_prob,
-            None,
-        )  # Entropy is None as it’s not directly meaningful here
+            dist.entropy(),
+        )

--- a/src/environments/mpc_policy.py
+++ b/src/environments/mpc_policy.py
@@ -50,6 +50,9 @@ class MPCPolicy(ActorCriticPolicy):
 
         # Environment and MPC setup
         self.env = env
+        self.horizon = horizon
+        self.lqr_iter = lqr_iter
+        self.R_scale = R_scale
 
         self.mpc_controller = MPCController(self.env, horizon, lqr_iter, R_scale)
 

--- a/src/environments/mpc_wrapper.py
+++ b/src/environments/mpc_wrapper.py
@@ -1,0 +1,57 @@
+import numpy as np
+import torch
+from gymnasium import Wrapper, spaces
+
+
+class MPCWrapper(Wrapper):
+    def __init__(self, env, mpc_controller):
+        super().__init__(env)
+        self.mpc_controller = mpc_controller
+
+        # Redefine action_space to match policy's output: 18D cost parameters
+        self.action_space = spaces.Box(low=-10, high=10, shape=(18,), dtype=np.float32)
+
+        # Store the last observation to access the current state
+        self.last_obs = None
+
+        self.state_dim = 4  # TODO: Generalize!!!
+
+    def step(self, action):
+        """
+        Convert 18D cost parameters to 5D control actions and step the environment.
+        Action: numpy array of shape (18,) from PPO policy.
+        """
+        if self.last_obs is None:
+            raise ValueError("Environment must be reset before stepping.")
+
+        # Extract current state from the last observation
+        # Assuming observation is a dict with "beam" as the state
+        obs = torch.tensor(self.last_obs, dtype=torch.float32)
+        current_state = obs[: self.state_dim].to(torch.float32)
+
+        # Convert numpy action to torch tensor
+        action = torch.tensor(action, dtype=torch.float32)
+        q_diag = torch.exp(action[:9])  # First 9 elements for q_diag
+        p = action[9:]  # Last 9 elements for p
+
+        # Compute 5D control action using MPC
+        control_action = self.mpc_controller.get_action_from_cost_params(
+            current_state, q_diag, p
+        )
+        control_action = (
+            control_action.detach().cpu().numpy()
+        )  # Convert to numpy for env
+
+        # Step the underlying environment with the 5D control action
+        next_obs, reward, terminated, truncated, info = self.env.step(control_action)
+
+        self.last_obs = next_obs  # Update last observation
+
+        return next_obs, reward, terminated, truncated, info
+
+    def reset(self, **kwargs):
+        """Reset the environment and store the initial observation."""
+        obs, info = self.env.reset(**kwargs)
+
+        self.last_obs = obs  # Store the dictionary for internal use
+        return obs, info

--- a/src/environments/mpc_wrapper.py
+++ b/src/environments/mpc_wrapper.py
@@ -13,8 +13,7 @@ class MPCWrapper(Wrapper):
 
         # Store the last observation to access the current state
         self.last_obs = None
-
-        self.state_dim = 4  # TODO: Generalize!!!
+        self.state_dim = env.unwrapped.observation_space["beam"].shape[0] # [x, y, x_sigma, y_sigma]
 
     def step(self, action):
         """

--- a/src/train/trainer.py
+++ b/src/train/trainer.py
@@ -83,6 +83,10 @@ def main() -> None:
         "log_std_init": 0.0,
         # SB3 config
         "sb3_device": "auto",
+        # ===== MPC parameters =====
+        "horizon": 5,
+        "lqr_iter": 5,
+        "R_scale": 0.01,
     }
     train(config)
 
@@ -183,7 +187,6 @@ def train(config: dict) -> None:
 
     # Train using a single environment
     model = PPO(
-        #"MlpPolicy",
         MPCPolicy,
         train_env,
         learning_rate=config["learning_rate"],
@@ -299,7 +302,12 @@ def make_env(
         )
 
     # Wrap environment around a differential MPC
-    mpc_controller = MPCController(env)
+    mpc_controller = MPCController(
+        env,
+        horizon=config["horizon"],
+        lqr_iter=config["lqr_iter"],
+        R_scale=config["R_scale"]
+    )
 
     # Wrap with MPCWrapper (handles 18D cost parameters)
     env = MPCWrapper(env, mpc_controller)

--- a/src/train/trainer.py
+++ b/src/train/trainer.py
@@ -182,7 +182,8 @@ def train(config: dict) -> None:
 
     # Train using a single environment
     model = PPO(
-        "MlpPolicy",
+        #"MlpPolicy",
+        MPCPolicy,
         train_env,
         learning_rate=config["learning_rate"],
         n_steps=config["n_steps"],
@@ -270,10 +271,8 @@ def make_env(
         render_mode="rgb_array",
         reward_signals=config["reward_signals"],
     )
-
-    # Wrap environment ina differential MPC
+    # Wrap environment around a differential MPC
     env = MPCController(env)
-
     env = TimeLimit(env, config["max_episode_steps"])
     if plot_episode:
         env = PlotEpisode(


### PR DESCRIPTION
This PR integrates a Proximal Policy Optimization (PPO)-based controller for beam control in the Cheetah-Accelerator simulation, following the methodology outlined in ["Actor-Critic Model Predictive Control: Differentiable Optimization meets Reinforcement Learning"](https://arxiv.org/pdf/2306.09852).

🔧 Key Contributions:

- Implements an actor-critic-based differentiable MPC scheme, where the critic is trained via a differentiable optimizer.
- Adapts the framework to beam dynamics in the [Cheetah-Accelerator](https://cheetah-accelerator.readthedocs.io/en/latest/examples/gradientbased.html) environment.
- Establishes a baseline PPO agent with integrated gradient-based trajectory optimization to guide policy learning.
- Enables end-to-end learning of closed-loop beam control policies that combine trajectory planning (via MPC) with policy generalization (via PPO).

📌 Notes:

- This approach improves sample efficiency and stability by embedding physics-informed trajectory rollouts into the policy optimization loop.
- Modular design facilitates ablation studies and future extension to multi-agent or hybrid control settings.